### PR TITLE
updated env formation step

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,0 +1,12 @@
+PORT=5000
+MONGO_URI=Mongo_Connection_URL
+JWT_SECRET=secret_key
+JWT_EXPIRES_IN=7d
+JWT_COOKIE_EXPIRE=7d
+CONTACT_EMAIL=your@email.id
+CRYPTR_SECRET=your_secret_code
+CLIENT_ID=your_secret_id
+CLIENT_SECRET=your_secret
+REFRESH_TOKEN=refresh_token
+VERIFY_MAIL=admin_emails_separated_by_comma
+BASE_LINK=http://localhost:5000_or_http://anubhav.aitoss.club_depending_upon_environment

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ BASE_LINK=http://localhost:5000_or_http://anubhav.aitoss.club_depending_upon_env
 ```
 Replace the dummy values with your credentials (Never share .env file with anyone)
 
+OR
+
+Just run this command instead of doing above step
+
+```
+cp .env_sample .env
+```
+
 Run the command in your terminal to start the dev server
 
 ```bash


### PR DESCRIPTION
Scenario - When any developer, came for the first time, he/she have to create a .env file and then copy-paste the content from the readme. This seems a bit boring :)

I have created a sample env, and via using the command `cp .env_sample .env `, the user can simply get the env at its place. Now he/she can just simply reply the fields needed with their tokens and work is done